### PR TITLE
Validate builds using ParseTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: haskell
+sudo: false
+ghc:
+  - 7.8 # Current Haskell Platform
+install:
+  # TODO: Replace with version on Hackage once ParseTS has an alpha out
+  - git clone https://github.com/BlocklandGlass/ParseTS.git parsets && cd parsets && cabal install --jobs && cd ..
+script:
+  - parsets .

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# BlocklandGlass [![Build Status](https://travis-ci.org/BlocklandGlass/BlocklandGlass.svg)](https://travis-ci.org/BlocklandGlass/BlocklandGlass)


### PR DESCRIPTION
This serves two purposes, both battle-testing ParseTS and keeping silly mistakes out of the repo. Ideally the checking could get more sophisticated later on.