### PR TITLE
settings button + disconnected cleanup stuff

### DIFF
--- a/client/GlassLive.cs
+++ b/client/GlassLive.cs
@@ -2326,10 +2326,10 @@ package GlassLivePackage {
     }
   }
 
-  function disconnectedCleanup(%a) {
+  function disconnectedCleanup(%doReconnect) {
     GlassLive::updateLocation(false);
 
-    parent::disconnectedCleanup(%a);
+    return parent::disconnectedCleanup(%doReconnect);
   }
 
   function GameConnection::onConnectionAccepted(%this, %a, %b, %c, %d, %e, %f, %g, %h, %i, %j, %k) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -826,7 +826,9 @@ function getServerSettingsBtn() {
   for(%i = 0; %i < %gui.getCount(); %i++) {
     %obj = %gui.getObject(%i);
 	
-    if(%obj.text $= "Server Settings >>")
+    if(%obj.command $= "AdminGui.clickServerSettings();"
+	|| %obj.command $= "openGlassSettings();"
+	&& %obj.text $= "Server Settings >>")
       return %obj;
   }
 }
@@ -886,7 +888,7 @@ package GlassServerControlC {
 	%serverSettingsBtn = getServerSettingsBtn();
 	
 	if(ServerConnection.hasGlass) {
-	  %serverSettingsBtn.command = "canvas.pushDialog(GlassServerControlGUI);";
+	  %serverSettingsBtn.command = "openGlassSettings();";
       %serverSettingsBtn.mcolor = "50 150 250 255"; // blue
 	} else {
 	  %serverSettingsBtn.command = "AdminGui.clickServerSettings();";

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -642,13 +642,13 @@ function GlassServerControlC::setEnabled(%this, %enabled) {
     GlassPrefGroup::cleanup();
   }
 
-  if(isObject(orbsServerControlBtn)) {
-    orbsServerControlBtn.command = "canvas.pushDialog(GlassServerControlGui);";
-  }
+  // if(isObject(orbsServerControlBtn)) {
+    // orbsServerControlBtn.command = "canvas.pushDialog(GlassServerControlGui);";
+  // }
 
-  if(isObject(rtbServerControlBtn)) {
-    rtbServerControlBtn.command = "canvas.pushDialog(GlassServerControlGui);";
-  }
+  // if(isObject(rtbServerControlBtn)) {
+    // rtbServerControlBtn.command = "canvas.pushDialog(GlassServerControlGui);";
+  // }
 }
 
 function GlassServerControlC::valueUpdate(%obj) {
@@ -820,35 +820,78 @@ function clientCmdGlassAdminListing(%data, %append) {
   }
 }
 
-return;
+function getServerSettingsBtn() {
+  %gui = adminGui.getObject(0);
+  
+  for(%i = 0; %i < %gui.getCount(); %i++) {
+    %obj = %gui.getObject(%i);
+	
+    if(%obj.text $= "Server Settings >>")
+      return %obj;
+  }
+}
 
 package GlassServerControlC {
-  function clientCmdsetAdminLevel(%level) {
-    if(%level > 0) {
-      GlassServerControlC.setEnabled(true);
-    } else {
-      GlassServerControlC.setEnabled(false);
-    }
-    parent::clientCmdsetAdminLevel(%level);
+  // function clientCmdsetAdminLevel(%level) {
+    // if(%level > 0) {
+      // GlassServerControlC.setEnabled(true);
+    // } else {
+      // GlassServerControlC.setEnabled(false);
+    // }
+    // parent::clientCmdsetAdminLevel(%level);
+  // }
+
+  // function NewPlayerListGui::update(%this, %a, %b, %c, %d, %e, %f) {
+    // parent::update(%this, %a, %b, %c, %d, %e, %f);
+    // GlassServerControlGui.onWake();
+  // }
+
+  // function GameConnection::setConnectArgs(%a, %b, %c, %d, %e, %f, %g, %h, %i, %j, %k, %l, %m, %n, %o,%p) {
+		// return parent::setConnectArgs(%a, %b, %c, %d, %e, %f, %g, "Glass" TAB Glass.version TAB GlassClientManager.getClients() NL %h, %i, %j, %k, %l, %m, %n, %o, %p);
+	// }
+
+  function disconnect(%doReconnect) {
+    GlassPrefGroup::cleanup();
+    return parent::disconnect(%doReconnect);
   }
 
-  function NewPlayerListGui::update(%this, %a, %b, %c, %d, %e, %f) {
-    parent::update(%this, %a, %b, %c, %d, %e, %f);
-    GlassServerControlGui.onWake();
+  function disconnectedCleanup(%doReconnect) {
+    GlassPrefGroup::cleanup();
+    return parent::disconnectedCleanup(%doReconnect);
   }
-
-  function GameConnection::setConnectArgs(%a, %b, %c, %d, %e, %f, %g, %h, %i, %j, %k, %l, %m, %n, %o,%p) {
-		return parent::setConnectArgs(%a, %b, %c, %d, %e, %f, %g, "Glass" TAB Glass.version TAB GlassClientManager.getClients() NL %h, %i, %j, %k, %l, %m, %n, %o, %p);
+  
+  function adminGui::onWake(%this) {
+	parent::onWake(%this);
+	
+	// RTB
+	
+	if(isObject(rtbServerControlBtn)) {
+	  if(ServerConnection.hasGlass)
+	    rtbServerControlBtn.setVisible(false);
+	  else
+	    rtbServerControlBtn.setVisible(true);
 	}
-
-  function disconnect(%a) {
-    GlassPrefGroup::cleanup();
-    parent::disconnect(%a);
-  }
-
-  function disconnectCleanup(%a) {
-    GlassPrefGroup::cleanup();
-    parent::disconnectCleanup(%a);
+	
+	// oRBs
+	
+	if(isObject(orbsServerControlBtn)) {
+	  if(ServerConnection.hasGlass)
+	    orbsServerControlBtn.setVisible(false);
+	  else
+	    orbsServerControlBtn.setVisible(true);
+	}
+	
+	// glass (takes over BL's standard server settings btn)
+	
+	%serverSettingsBtn = getServerSettingsBtn();
+	
+	if(ServerConnection.hasGlass) {
+	  %serverSettingsBtn.command = "canvas.pushDialog(GlassServerControlGUI);";
+      %serverSettingsBtn.mcolor = "50 150 250 255"; // blue
+	} else {
+	  %serverSettingsBtn.command = "AdminGui.clickServerSettings();";
+      %serverSettingsBtn.mcolor = "255 255 255 255";
+	}
   }
 };
 activatePackage(GlassServerControlC);

--- a/server.cs
+++ b/server.cs
@@ -43,9 +43,9 @@ function Glass::execServer() {
 	GlassResourceManager::execResource("Support_Preferences", "server");
 	GlassResourceManager::execResource("Support_Updater", "server");
 
-	GlassServerControlS::init();
+	//GlassServerControlS::init();
 	GlassAuthS::init();
-	GlassServerInfo::connectToServer();
+	//GlassServerInfo::connectToServer();
 	//GlassInfoServer::init();
 
 	GlassAuthS::init();


### PR DESCRIPTION
* glass now intercepts blockland's standard server settings button,
colors it blue and redirects it to openGlassSettings(); (original
functionality/color is automatically restored on a non-glass server).
* orbs/rtb buttons will automatically be hidden (not deleted) from the
admin gui, and unhidden appropriately when joining a non-glass server with either systems installed.
* uncommented disconnectedcleanup functionality and changed %a to %doReconnect (as named in BL's original function).
* commented 2 executed functions in the server.cs, they don't exist and
thus cause an error in the console.