### PR TITLE
Add color selector for "colorset" preference type

### DIFF
--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -243,7 +243,11 @@ function GlassServerControlC::renderCategory(%category) {
     }
   }
 
-  %parent.verticalMatchChildren(123, 0);
+  %scrollParent = GlassServerControl_PrefScroll.getGroup();
+  // Fill up any extra space in the scroll control.
+  %paddingY = getMax(0, getWord(%scrollParent.extent, 1) - %currentY - 2);
+  %parent.verticalMatchChildren(0, %paddingY);
+
   %category.tab = %parent;
 
   %parent.setName("GlassServerControlGui_Pref" @ %category.id);

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -929,6 +929,7 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
     }
   }
 
+
   // Calculate extents of container elements.
   %swatExtY = mCeil(%count / %maxColumns) * %size;
   %extX = %maxColumns * %size;
@@ -940,11 +941,16 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
   // Find the (x, y) position of the upper left corner of %swatch.btn relative to %swatch's parent.
   %trueBtnX = getWord(%swatch.position, 0) + getWord(%swatch.btn.position, 0);
   %trueBtnY = getWord(%swatch.position, 1) + getWord(%swatch.btn.position, 1);
-  %menu.position = (%trueBtnX - getWord(%menu.extent, 0)) SPC %trueBtnY;
-  // TODO: clamp position to be inside the parent swatch.
+
+  %parent = %swatch.getGroup();
+  %parentExtY = getWord(%parent.extent, 1);
+
+  // Ensure color menu doesn't extend out of reach.
+  %menuY = mClampF(%trueBtnY, 0, %parentExtY - getWord(%menu.extent, 1));
+  %menu.position = (%trueBtnX - getWord(%menu.extent, 0)) SPC %menuY;
 
   %swatch.colorMenu = %menu;
-  %swatch.getGroup().add(%swatch.colorMenu);
+  %parent.add(%swatch.colorMenu);
 }
 
 function GlassServerControlC::valueUpdate(%obj) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -132,33 +132,27 @@ function GlassServerControlC::renderCategory(%category) {
     switch$(%pref.type) {
       case "bool":
         %swatch = GlassServerControlC::createCheckbox();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(%pref.value);
 
       case "num":
         %swatch = GlassServerControlC::createInt();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(%pref.value);
 
       case "slider":
         %swatch = GlassServerControlC::createSlider();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(%pref.value);
         %swatch.ctrl.range = %pref.parm;
 
       case "string":
         %swatch = GlassServerControlC::createText();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(expandEscape(%pref.value));
 
       case "textarea":
         %swatch = GlassServerControlC::createTextArea();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(%pref.value);
 
       case "dropdown":
         %swatch = GlassServerControlC::createList();
-        %swatch.text.setText(%pref.title);
         %options = %pref.params;
         for(%k = 0; %k < getWordCount(%options); %k += 2) {
           %swatch.ctrl.add(strreplace(getWord(%options, %k), "_", " "), getWord(%options, %k+1));
@@ -167,7 +161,6 @@ function GlassServerControlC::renderCategory(%category) {
 
       case "playercount":
         %swatch = GlassServerControlC::createList();
-        %swatch.text.setText(%pref.title);
         %options = %pref.params;
         for(%k = 0; %k < 99; %k++) {
           %swatch.ctrl.add(%k+1, %k+1);
@@ -176,7 +169,6 @@ function GlassServerControlC::renderCategory(%category) {
 
       case "wordlist":
         %swatch = GlassServerControlC::createText();
-        %swatch.text.setText(%pref.title);
         %swatch.ctrl.setValue(expandEscape(%pref.value));
 
       case "userlist": // these should be done at some point
@@ -187,7 +179,6 @@ function GlassServerControlC::renderCategory(%category) {
 
       case "rgb":
         %swatch = GlassServerControlC::createRGB();
-        %swatch.text.setText(%pref.title);
 
         %alpha = %pref.params;
         if(%alpha) {
@@ -198,7 +189,6 @@ function GlassServerControlC::renderCategory(%category) {
 
       case "color":
 	%swatch = GlassServerControlC::createColor();
-        %swatch.text.setText(%pref.title);
 	%color = getColorFromTable(%pref.value);
 	%swatch.btnBack.color = %color;
 
@@ -227,6 +217,7 @@ function GlassServerControlC::renderCategory(%category) {
 
     %odd = !%odd;
 
+    %swatch.text.setText(%pref.title);
     if (isObject(%swatch.ctrl)) {
       %swatch.ctrl.command = "GlassServerControlC::valueUpdate(" @ %swatch.getId() @ ");";
     }
@@ -818,7 +809,8 @@ function GlassServerControlC::setEnabled(%this, %enabled) {
 // @param int i ID of color in colorset table in the range [0, 65].
 // @return words RGBA values in the range [0, 255].
 function getColorFromTable(%i) {
-  // TODO: is getColorIdTable updated on join or spawn?
+  // TODO: the internal color table for getColorIdTable is only updated once the client spawns.
+  //       Need to somehow communicate the true color table to the client on join.
   %color = getColorIdTable(%i);
   // Scale color up from [0, 1] to [0, 255].
   %color = mCeil(getWord(%color, 0) * 255)
@@ -928,7 +920,6 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
       %count++;
     }
   }
-
 
   // Calculate extents of container elements.
   %swatExtY = mCeil(%count / %maxColumns) * %size;

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -134,58 +134,8 @@ function GlassServerControlC::renderCategory(%category) {
         %swatch = GlassServerControlC::createCheckbox();
         %swatch.ctrl.setValue(%pref.value);
 
-      case "num":
-        %swatch = GlassServerControlC::createInt();
-        %swatch.ctrl.setValue(%pref.value);
-
-      case "slider":
-        %swatch = GlassServerControlC::createSlider();
-        %swatch.ctrl.setValue(%pref.value);
-        %swatch.ctrl.range = %pref.parm;
-
-      case "string":
-        %swatch = GlassServerControlC::createText();
-        %swatch.ctrl.setValue(expandEscape(%pref.value));
-
-      case "textarea":
-        %swatch = GlassServerControlC::createTextArea();
-        %swatch.ctrl.setValue(%pref.value);
-
-      case "dropdown":
-        %swatch = GlassServerControlC::createList();
-        %options = %pref.params;
-        for(%k = 0; %k < getWordCount(%options); %k += 2) {
-          %swatch.ctrl.add(strreplace(getWord(%options, %k), "_", " "), getWord(%options, %k+1));
-        }
-        %swatch.ctrl.setSelected(%pref.value);
-
-      case "playercount":
-        %swatch = GlassServerControlC::createList();
-        %options = %pref.params;
-        for(%k = 0; %k < 99; %k++) {
-          %swatch.ctrl.add(%k+1, %k+1);
-        }
-        %swatch.ctrl.setSelected(%pref.value);
-
-      case "wordlist":
-        %swatch = GlassServerControlC::createText();
-        %swatch.ctrl.setValue(expandEscape(%pref.value));
-
-      case "userlist": // these should be done at some point
-        %swatch = "unfinished";
-
       case "button":
         %swatch = "unfinished";
-
-      case "rgb":
-        %swatch = GlassServerControlC::createRGB();
-
-        %alpha = %pref.params;
-        if(%alpha) {
-          %swatch.preview.color = %pref.value;
-        } else {
-          %swatch.preview.color = getWords(%pref.value, 0, 3) SPC 255;
-        }
 
       case "color":
 	%swatch = GlassServerControlC::createColor();
@@ -200,6 +150,56 @@ function GlassServerControlC::renderCategory(%category) {
 
       case "datablocklist":
         %swatch = "unfinished";
+
+      case "dropdown":
+        %swatch = GlassServerControlC::createList();
+        %options = %pref.params;
+        for(%k = 0; %k < getWordCount(%options); %k += 2) {
+          %swatch.ctrl.add(strreplace(getWord(%options, %k), "_", " "), getWord(%options, %k+1));
+        }
+        %swatch.ctrl.setSelected(%pref.value);
+
+      case "num":
+        %swatch = GlassServerControlC::createInt();
+        %swatch.ctrl.setValue(%pref.value);
+
+      case "playercount":
+        %swatch = GlassServerControlC::createList();
+        %options = %pref.params;
+        for(%k = 0; %k < 99; %k++) {
+          %swatch.ctrl.add(%k+1, %k+1);
+        }
+        %swatch.ctrl.setSelected(%pref.value);
+
+      case "rgb":
+        %swatch = GlassServerControlC::createRGB();
+
+        %alpha = %pref.params;
+        if(%alpha) {
+          %swatch.preview.color = %pref.value;
+        } else {
+          %swatch.preview.color = getWords(%pref.value, 0, 3) SPC 255;
+        }
+
+      case "slider":
+        %swatch = GlassServerControlC::createSlider();
+        %swatch.ctrl.setValue(%pref.value);
+        %swatch.ctrl.range = %pref.parm;
+
+      case "string":
+        %swatch = GlassServerControlC::createText();
+        %swatch.ctrl.setValue(expandEscape(%pref.value));
+
+      case "textarea":
+        %swatch = GlassServerControlC::createTextArea();
+        %swatch.ctrl.setValue(%pref.value);
+
+      case "userlist": // these should be done at some point
+        %swatch = "unfinished";
+
+      case "wordlist":
+        %swatch = GlassServerControlC::createText();
+        %swatch.ctrl.setValue(expandEscape(%pref.value));
     }
 
     if(!isObject(%swatch)) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -136,13 +136,10 @@ function GlassServerControlC::renderCategory(%category) {
       case "button":
 	%swatch = "unfinished";
 
-      case "color":
-	%swatch = GlassServerControlC::createColor();
+      case "colorset":
+	%swatch = GlassServerControlC::createColorset();
 	%color = getColorFromTable(%pref.value);
 	%swatch.btnBack.color = %color;
-
-      case "colorset":
-        %swatch = "unfinished";
 
       case "datablock":
         %swatch = "unfinished";
@@ -720,7 +717,7 @@ function GlassServerControlC::createRGB() {
 
 // Creates a GUI control element for modifying a color preference.
 // @return GuiSwatchCtrl GUI element containing color setter.
-function GlassServerControlC::createColor() {
+function GlassServerControlC::createColorset() {
   // Size of color buttons (buttons are square).
   %size = 18;
 
@@ -817,7 +814,7 @@ function getColorFromTable(%i) {
 }
 
 // Updates the preferences for a color preference swatch.
-// @param GuiSwatchCtrl swatch Swatch control created by GlassServerControlC::createColor().
+// @param GuiSwatchCtrl swatch Swatch control created by GlassServerControlC::createColorset().
 // @param int i ID of color in colorset table in the range [0, 65].
 function GlassServerControlC::updateColorPref(%swatch, %i) {
   %color = getColorFromTable(%i);
@@ -829,7 +826,7 @@ function GlassServerControlC::updateColorPref(%swatch, %i) {
 // left of the swatch. If a color menu previously created by this function exists, it will be
 // deleted.
 // @param GuiSwatchCtrl swatch Swatch control to bind menu to, created by
-//    GlassServerControlC::createColor().
+//    GlassServerControlC::createColorset().
 // @param number x X position of upper right corner of menu.
 // @param number y Y position of upper right corner of menu.
 function GlassServerControlC::spawnColorMenu(%swatch) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -844,7 +844,12 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
 
   // If a color menu already exists for %swatch, delete it.
   if (isObject(GlassServerControlGui.colorMenu)) {
+    // If the color menu belongs to %swatch, do not create a new one.
+    %exit = isObject(%swatch.colorMenu);
     GlassServerControlGui.colorMenu.delete();
+    if (%exit) {
+      return;
+    }
   }
 
   // Create container for color buttons.
@@ -936,7 +941,8 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
   %menu.position = (%trueBtnX - getWord(%menu.extent, 0)) SPC %menuY;
 
   GlassServerControlGui.colorMenu = %menu;
-  %parent.add(GlassServerControlGui.colorMenu);
+  %swatch.colorMenu = %menu;
+  %parent.add(%swatch.colorMenu);
 }
 
 function GlassServerControlC::valueUpdate(%obj) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -826,7 +826,8 @@ function GlassServerControlC::updateColorPref(%swatch, %i) {
 }
 
 // Creates a menu for selecting a color from the currently loaded colorset. Menu is created to the
-// left of the color preference swatch's color button.
+// left of the swatch. If a color menu previously created by this function exists, it will be
+// deleted.
 // @param GuiSwatchCtrl swatch Swatch control to bind menu to, created by
 //    GlassServerControlC::createColor().
 // @param number x X position of upper right corner of menu.
@@ -842,9 +843,8 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
   %size = 18;
 
   // If a color menu already exists for %swatch, delete it.
-  if (isObject(%swatch.colorMenu)) {
-    %swatch.colorMenu.delete();
-    return;
+  if (isObject(GlassServerControlGui.colorMenu)) {
+    GlassServerControlGui.colorMenu.delete();
   }
 
   // Create container for color buttons.
@@ -857,7 +857,7 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
     vScrollBar = "alwaysOn";
     enabled = true;
     visible = true;
-    clipToParent = false;
+    clipToParent = true;
   };
   %menuSwatch = new GuiSwatchCtrl() {
     profile = "GuiDefaultProfile";
@@ -935,8 +935,8 @@ function GlassServerControlC::spawnColorMenu(%swatch) {
   %menuY = mClampF(%trueBtnY, 0, %parentExtY - getWord(%menu.extent, 1));
   %menu.position = (%trueBtnX - getWord(%menu.extent, 0)) SPC %menuY;
 
-  %swatch.colorMenu = %menu;
-  %parent.add(%swatch.colorMenu);
+  GlassServerControlGui.colorMenu = %menu;
+  %parent.add(GlassServerControlGui.colorMenu);
 }
 
 function GlassServerControlC::valueUpdate(%obj) {

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -835,7 +835,6 @@ function GlassServerControlC::updateColorPref(%swatch, %i) {
 //    GlassServerControlC::createColor().
 // @param number x X position of upper right corner of menu.
 // @param number y Y position of upper right corner of menu.
-//function GlassServerControlC::createColorMenu(%swatch, %x, %y) { // TODO: remove
 function GlassServerControlC::spawnColorMenu(%swatch) {
   // Maximum height of scroll view.
   %maxHeight = 100;

--- a/client/GlassServerControl.cs
+++ b/client/GlassServerControl.cs
@@ -128,14 +128,13 @@ function GlassServerControlC::renderCategory(%category) {
       %currentY += 24;
     }
     %swatch = "";
-    // TODO: call %swatch.text.setText(%pref.title) only once
     switch$(%pref.type) {
       case "bool":
         %swatch = GlassServerControlC::createCheckbox();
         %swatch.ctrl.setValue(%pref.value);
 
       case "button":
-        %swatch = "unfinished";
+	%swatch = "unfinished";
 
       case "color":
 	%swatch = GlassServerControlC::createColor();
@@ -673,10 +672,9 @@ function GlassServerControlC::createRGB() {
      vertSizing = "bottom";
      position = "1 25";
      extent = "430 32";
-     minExtent = "8 2";
-     enabled = "1";
-     visible = "1";
-     clipToParent = "1";
+     enabled = true;
+     visible = true;
+     clipToParent = true;
      color = "100 100 100 50";
   };
 
@@ -686,10 +684,9 @@ function GlassServerControlC::createRGB() {
     vertSizing = "center";
     position = "10 7";
     extent = "77 18";
-    minExtent = "8 2";
-    enabled = "1";
-    visible = "1";
-    clipToParent = "1";
+    enabled = true;
+    visible = true;
+    clipToParent = true;
     text = "";
     maxLength = "255";
   };
@@ -698,12 +695,11 @@ function GlassServerControlC::createRGB() {
     profile = "GuiDefaultProfile";
     horizSizing = "right";
     vertSizing = "center";
-    position = "408 8";
+    position = "403 8";
     extent = "16 16";
-    minExtent = "8 2";
-    enabled = "1";
-    visible = "1";
-    clipToParent = "1";
+    enabled = true;
+    visible = true;
+    clipToParent = true;
     color = "255 0 255 255";
   };
 
@@ -711,7 +707,7 @@ function GlassServerControlC::createRGB() {
     profile = "GuiDefaultProfile";
     horizSizing = "right";
     vertSizing = "center";
-    position = "408 8";
+    position = "403 8";
     extent = "16 16";
     command = "GlassServerControlGui::openColorSelector(" @ %swatch.getId() @ ");";
   };


### PR DESCRIPTION
The added color selector behaves almost identically to that used in the Player Appearance menu. The color selector/menu is a scroll-able menu with buttons, each corresponding to a color in the currently loaded colorset.

The assumption was made that "color" is an unintentional duplicate of "colorset". Note that "color" is not recognized as a valid preference type [in Support_Preferences](https://github.com/BlocklandGlass/blockland-preferences/blob/ae843877abdf0efca1b8e14af81c584f6a2aa03d/class/preference.cs#L288), whereas "colorset" is:
```
  %valid = ":playercount:wordlist:datablocklist:userlist:datablock:slider:num:bool:button:dropdown:string:rgb:colorset";
```

This additional was verified to work with the following preference definition:
```
new ScriptObject(Preference) {
  className      = "TestPrefColor1";
  addon          = "System_GlassTest";
  category       = "General";
  title          = "Color test 1";

  type           = "colorset";

  defaultValue   = "0";

  variable       = "$Pref::GlassTest::TestColorPref1";

  hostOnly       = true;
  secret         = false;

  loadNow        = false;
  noSave         = false;
  requireRestart = false;
};
```

This pull request should solve issue #258 (_Preferences - Colorset type does not show up in GUI_).