### PR TITLE
Auto decline friend requests from blocked users

### DIFF
--- a/client/submodules/live/GlassLiveConnection.cs
+++ b/client/submodules/live/GlassLiveConnection.cs
@@ -465,6 +465,15 @@ function GlassLiveConnection::onLine(%this, %line) {
 				%username = %data.sender;
 				%uo = GlassLiveUser::create(%username, %blid);
 
+				if(%uo.isBlocked()) {
+					%obj = JettisonObject();
+					%obj.set("type", "string", "friendDecline");
+					%obj.set("blid", "string", %blid);
+
+					GlassLiveConnection.send(jettisonStringify("object", %obj) @ "\r\n");
+					return;
+				}
+
 				GlassLive::addFriendRequestToList(%uo);
 				GlassLive::createFriendList();
 


### PR DESCRIPTION
Simple change to hide and automatically decline friend requests from blocked users on the client side. 