### PR TITLE
Potential fix for Glass authentication issues (#279, "Signed out" bug, blank mod manager, etc.)

### DIFF
--- a/client/GlassAuth.cs
+++ b/client/GlassAuth.cs
@@ -250,7 +250,9 @@ function GlassAuthTCP::onDone(%this, %error) {
           if(GlassAuth.usingDAA) {
             GlassAuth.ident = GlassAuth.daa_opaque;
           } else {
-            GlassAuth.ident = %object.ident;
+            if(%object.ident !$= "") {
+              GlassAuth.ident = %object.ident;
+            }
           }
 
           //there is an unverified web account associated with this blid


### PR DESCRIPTION
Potential fix for #279 

What's happening here is GlassAuth.ident is being set to a blank string "" with no recovery. This change is a quick-fix check for the value, leaving GlassAuth.ident the same if %object.ident is blank.

The affecting code was introduced in 38c37f8, dated *2017*, indicating that there's likely some other factor indirectly resulting in the problem. As such, I suspect there might be a more suitable fix, or possibly some other side effects to this fix. Regardless, this does test successfully in fixing the issue on my end.