### PR TITLE
Fix "Unable to find object: '' attempting to call function 'resize'" on use of mod manager search

### DIFF
--- a/support/dynamicgui.cs
+++ b/support/dynamicgui.cs
@@ -100,7 +100,7 @@ function GuiControl::setMarginResizeParent(%this, %a, %b, %c, %d) {
   %groupLeft = getWord(%this.getGroup().position, 0);
   %groupTop  = getWord(%this.getGroup().position, 1);
   //%this.getGroup().extent = %x SPC %y;
-  %this.group.resize(%groupLeft, %groupTop, %x, %y);
+  %this.getGroup().resize(%groupLeft, %groupTop, %x, %y);
 }
 
 function GuiControl::forceCenter(%this) {


### PR DESCRIPTION
Fix the use of getGroup() in GuiControl::setMarginResizeParent.

This will fix "Unable to find object: '' attempting to call function 'resize'" console spam when using the search function.