### PR TITLE
Fix "Unable to find function strtrim" in mod manager

### DIFF
--- a/client/submodules/modmanager/boardPage.cs
+++ b/client/submodules/modmanager/boardPage.cs
@@ -109,7 +109,7 @@ function GMM_BoardPage::handleResults(%this, %res) {
     %author = getASCIIString(%addon.author);
     %downloads = %addon.downloads;
 
-    if(strtrim(%addon.summary) $= "")
+    if(trim(%addon.summary) $= "")
       %summary = "< No Summary >";
     else
       %summary = getASCIIString(%addon.summary);


### PR DESCRIPTION
Presumably the intention was to use the `trim` function here? I've changed it to that. 